### PR TITLE
only fetch the latest git revision

### DIFF
--- a/build_git.sh
+++ b/build_git.sh
@@ -5,7 +5,7 @@ echo "This may take some time, please sit back and take a coffee."
 echo ""
 
 mkdir -p output
-git clone git://github.com/git/git
+git clone --depth 1 --shallow-submodules git://github.com/git/git
 cd git
 
 export NO_OPENSSL=1


### PR DESCRIPTION
if you don't want the entire revision history of git, but only the latest revision, this speeds up the cloning process/bandwidth/diskspace

- on my laptop, this took the cloning process down from 83.5 seconds to 6.4 seconds, and diskspace requirements down from 230 MB to 59 MB

root@xDevAd:/temp2/test# time git clone --depth 1 --shallow-submodules git://github.com/git/git
Cloning into 'git'...
remote: Enumerating objects: 4080, done.
remote: Counting objects: 100% (4080/4080), done.
remote: Compressing objects: 100% (3599/3599), done.
remote: Total 4080 (delta 379), reused 1931 (delta 311), pack-reused 0
Receiving objects: 100% (4080/4080), 9.83 MiB | 3.69 MiB/s, done.
Resolving deltas: 100% (379/379), done.

real	0m6,418s
user	0m1,194s
sys	0m0,786s
root@xDevAd:/temp2/test# mv git git_shallow
root@xDevAd:/temp2/test# time git clone git://github.com/git/git
Cloning into 'git'...
remote: Enumerating objects: 314519, done.
remote: Counting objects: 100% (1619/1619), done.
remote: Compressing objects: 100% (818/818), done.
remote: Total 314519 (delta 1054), reused 1188 (delta 801), pack-reused 312900
Receiving objects: 100% (314519/314519), 172.30 MiB | 3.26 MiB/s, done.
Resolving deltas: 100% (234622/234622), done.
Updating files: 100% (3982/3982), done.

real	1m23,581s
user	1m4,861s
sys	0m19,944s
root@xDevAd:/temp2/test# du -h git_shallow | tail -n1
59M	git_shallow
root@xDevAd:/temp2/test# du -h git | tail -n1
230M	git